### PR TITLE
Initial drop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,12 @@
+version: 2
+jobs:
+  build:
+    machine: true
+    steps:
+    - checkout
+
+    - run: |
+        wget -q $(curl -sS -H "Authorization: token $RELEASE_TOKEN" https://api.github.com/repos/giantswarm/architect/releases/latest | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
+        chmod +x ./architect
+        ./architect version
+    - run: ./architect build

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+kube-netcheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.7
+
+ADD kube-netcheck /usr/bin/kube-netcheck
+ENTRYPOINT ["/usr/bin/kube-netcheck"]

--- a/examples/quickstart.yaml
+++ b/examples/quickstart.yaml
@@ -1,0 +1,46 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-netcheck
+  namespace: kube-system
+  labels:
+    app: kube-netcheck
+spec:
+  ports:
+    - port: 6666
+  selector:
+    app: kube-netcheck
+
+---
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: kube-netcheck
+  namespace: kube-system
+  labels:
+    app: kube-netcheck
+spec:
+  template:
+    metadata:
+      labels:
+        app: kube-netcheck
+    spec:
+      tolerations:
+        # Allow the pod to run on the master.  This is required for
+        # the master to communicate with pods.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: kube-netcheck
+          image: quay.io/giantswarm/kube-netcheck:latest
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 6666

--- a/helm/kube-netcheck-chart/Chart.yaml
+++ b/helm/kube-netcheck-chart/Chart.yaml
@@ -1,0 +1,2 @@
+name: kube-netcheck-chart
+version: 1.0.0-[[ .SHA ]]

--- a/helm/kube-netcheck-chart/templates/daemonset.yaml
+++ b/helm/kube-netcheck-chart/templates/daemonset.yaml
@@ -1,0 +1,32 @@
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: kube-netcheck
+  namespace: kube-system
+  labels:
+    app: kube-netcheck
+spec:
+  template:
+    metadata:
+      labels:
+        app: kube-netcheck
+    spec:
+      tolerations:
+        # Allow the pod to run on the master.  This is required for
+        # the master to communicate with pods.
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: kube-netcheck
+          image: quay.io/giantswarm/kube-netcheck:latest
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              cpu: 50m
+              memory: 50Mi
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 6666

--- a/helm/kube-netcheck-chart/templates/service.yaml
+++ b/helm/kube-netcheck-chart/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-netcheck
+  namespace: kube-system
+  labels:
+    app: kube-netcheck
+spec:
+  ports:
+    - port: 6666
+  selector:
+    app: kube-netcheck

--- a/main.go
+++ b/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"runtime"
+	"time"
+)
+
+const checkInterval = 10 * time.Second
+
+// Common variables.
+var (
+	description string = "Simple network checker for Kubernetes."
+	gitCommit   string = "n/a"
+	name        string = "kube-netcheck"
+	source      string = "https://github.com/giantswarm/kube-netcheck"
+)
+
+type Check interface {
+	Run() error
+}
+
+func main() {
+	// Print version.
+	if (len(os.Args) > 1) && (os.Args[1] == "version") {
+		fmt.Printf("Description:    %s\n", description)
+		fmt.Printf("Git Commit:     %s\n", gitCommit)
+		fmt.Printf("Go Version:     %s\n", runtime.Version())
+		fmt.Printf("Name:           %s\n", name)
+		fmt.Printf("OS / Arch:      %s / %s\n", runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("Source:         %s\n", source)
+		return
+	}
+
+	var serviceURL string
+	var listenSocket string
+	var help bool
+
+	flag.StringVar(&serviceURL, "service-url", "http://kube-netcheck:6666", "URL to connect to")
+	flag.StringVar(&listenSocket, "listen-socket", ":6666", "Run http server on socket")
+	flag.BoolVar(&help, "help", false, "Print usage and exit")
+	flag.Parse()
+
+	// Print usage.
+	if help {
+		flag.Usage()
+		return
+	}
+
+	// Default http handler with empty http response.
+	http.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintf(w, "")
+	})
+
+	// Run http listener.
+	log.Printf("Starting http listener on %s", listenSocket)
+	go func() {
+		log.Fatal(http.ListenAndServe(listenSocket, nil))
+	}()
+
+	for {
+		resp, err := http.Get(serviceURL)
+		if err != nil {
+			log.Fatal(err)
+		}
+		resp.Body.Close()
+
+		log.Printf("OK - Checked %s with response %s", serviceURL, resp.Status)
+
+		time.Sleep(checkInterval)
+	}
+}


### PR DESCRIPTION
Trivial daemonset that checks internal network connectivity in Kubernetes cluster.

Usage
```
kubectl apply -f examples/quickstart.yaml
# Give it few minutes
kubectl get pods  -n kube-system -l app=kube-netcheck
# If number of restarts is not 0 then there are some issues with network
```

Idea is the following:
- Every checker exposes http server on port 6666
- Every checker continuously sends http request to http://kube-netcheck:6666 (kubernetes service that load-balances between all checkers)
- At any error checker will exit